### PR TITLE
Support raw signing of hashes and aggregated verification

### DIFF
--- a/include/bls/bls.h
+++ b/include/bls/bls.h
@@ -84,6 +84,10 @@ BLS_DLL_API void blsSignHash(blsSignature *sig, const blsSecretKey *sec, const v
 // return 1 if valid
 BLS_DLL_API int blsVerifyHash(const blsSignature *sig, const blsPublicKey *pub, const void *h, mclSize size);
 
+// return 1 if valid, 0 if invalid or when duplicated hashes were provided
+// verify an aggregated signature given the public keys and message hashes. No duplicate message hashes allowed
+BLS_DLL_API int blsVerifyAggregatedHashes(const blsSignature *sig, const blsPublicKey *pubVec, const void *hashVec, mclSize hashSize, mclSize hashCount);
+
 // return written byte size if success else 0
 BLS_DLL_API mclSize blsIdSerialize(void *buf, mclSize maxBufSize, const blsId *id);
 BLS_DLL_API mclSize blsSecretKeySerialize(void *buf, mclSize maxBufSize, const blsSecretKey *sec);

--- a/include/bls/bls.h
+++ b/include/bls/bls.h
@@ -72,10 +72,17 @@ BLS_DLL_API int blsSecretKeySetLittleEndian(blsSecretKey *sec, const void *buf, 
 
 BLS_DLL_API void blsGetPublicKey(blsPublicKey *pub, const blsSecretKey *sec);
 
+// calculate the hash of m and sign the hash
 BLS_DLL_API void blsSign(blsSignature *sig, const blsSecretKey *sec, const void *m, mclSize size);
 
 // return 1 if valid
 BLS_DLL_API int blsVerify(const blsSignature *sig, const blsPublicKey *pub, const void *m, mclSize size);
+
+// sign the hash
+BLS_DLL_API void blsSignHash(blsSignature *sig, const blsSecretKey *sec, const void *h, mclSize size);
+
+// return 1 if valid
+BLS_DLL_API int blsVerifyHash(const blsSignature *sig, const blsPublicKey *pub, const void *h, mclSize size);
 
 // return written byte size if success else 0
 BLS_DLL_API mclSize blsIdSerialize(void *buf, mclSize maxBufSize, const blsId *id);

--- a/include/bls/bls.hpp
+++ b/include/bls/bls.hpp
@@ -228,6 +228,7 @@ public:
 	void setStr(const std::string& str, int ioMode = 0);
 	bool verify(const PublicKey& pub, const std::string& m) const;
 	bool verifyHash(const PublicKey& pub, const void *hash, size_t hashSize) const;
+	bool verifyAggregatedHashes(const PublicKey* pubs, const void* hashVec, size_t hashSize, size_t hashCount) const;
 	/*
 		verify self(pop) with pub
 	*/

--- a/include/bls/bls.hpp
+++ b/include/bls/bls.hpp
@@ -136,6 +136,7 @@ public:
 	void getPublicKey(PublicKey& pub) const;
 	// constant time sign
 	void sign(Signature& sig, const std::string& m) const;
+	void signHash(Signature& sig, const void* hash, size_t hashSize) const;
 	/*
 		make Pop(Proof of Possesion)
 		pop = prv.sign(pub)
@@ -226,6 +227,7 @@ public:
 	void getStr(std::string& str, int ioMode = 0) const;
 	void setStr(const std::string& str, int ioMode = 0);
 	bool verify(const PublicKey& pub, const std::string& m) const;
+	bool verifyHash(const PublicKey& pub, const void *hash, size_t hashSize) const;
 	/*
 		verify self(pop) with pub
 	*/

--- a/src/bls.cpp
+++ b/src/bls.cpp
@@ -283,10 +283,8 @@ void Signature::setStr(const std::string& str, int ioMode)
 	getInner().sHm.setStr(str, ioMode);
 }
 
-bool Signature::verify(const PublicKey& pub, const std::string& m) const
+static bool VerifyMappedHash(const G2& sQ, const G1& sHm, const G1& Hm)
 {
-	G1 Hm;
-	HashAndMapToG1(Hm, m); // Hm = Hash(m)
 #if 1
 	/*
 		e(P1, Q1) == e(P2, Q2)
@@ -297,16 +295,32 @@ bool Signature::verify(const PublicKey& pub, const std::string& m) const
 	*/
 	Fp12 e;
 	std::vector<Fp6> Q2coeff;
-	precomputeG2(Q2coeff, pub.getInner().sQ);
-	precomputedMillerLoop2(e, getInner().sHm, getQcoeff(), -Hm, Q2coeff);
+	precomputeG2(Q2coeff, sQ);
+	precomputedMillerLoop2(e, sHm, getQcoeff(), -Hm, Q2coeff);
 	finalExp(e, e);
 	return e.isOne();
 #else
 	Fp12 e1, e2;
-	pairing(e1, getInner().sHm, getQ()); // e(s Hm, Q)
-	pairing(e2, Hm, pub.getInner().sQ); // e(Hm, sQ)
+	pairing(e1, sHm, getQ()); // e(s Hm, Q)
+	pairing(e2, Hm, sQ); // e(Hm, sQ)
 	return e1 == e2;
 #endif
+}
+
+bool Signature::verify(const PublicKey& pub, const std::string& m) const
+{
+	G1 Hm;
+	HashAndMapToG1(Hm, m); // Hm = Hash(m)
+	return VerifyMappedHash(pub.getInner().sQ, getInner().sHm, Hm);
+}
+
+bool Signature::verifyHash(const PublicKey& pub, const void *hash, size_t hashSize) const
+{
+    G1 Hm;
+    Fp t;
+    t.setArrayMask((const char*)hash, hashSize);
+    BN::mapToG1(Hm, t);
+	return VerifyMappedHash(pub.getInner().sQ, getInner().sHm, Hm);
 }
 
 bool Signature::verify(const PublicKey& pub) const
@@ -432,6 +446,16 @@ void SecretKey::sign(Signature& sig, const std::string& m) const
 	HashAndMapToG1(Hm, m);
 //	G1::mul(sig.getInner().sHm, Hm, getInner().s);
 	G1::mulCT(sig.getInner().sHm, Hm, getInner().s);
+}
+
+void SecretKey::signHash(Signature& sig, const void* hash, size_t hashSize) const
+{
+    G1 Hm;
+    Fp t;
+    t.setArrayMask((const char*)hash, hashSize);
+    BN::mapToG1(Hm, t);
+//	G1::mul(sig.getInner().sHm, Hm, getInner().s);
+    G1::mulCT(sig.getInner().sHm, Hm, getInner().s);
 }
 
 void SecretKey::getPop(Signature& pop) const

--- a/src/bls_c.cpp
+++ b/src/bls_c.cpp
@@ -123,6 +123,15 @@ void blsSign(blsSignature *sig, const blsSecretKey *sec, const void *m, mclSize 
 	mclBnG1_mulCT(&sig->v, cast(&Hm), &sec->v);
 }
 
+void blsSignHash(blsSignature *sig, const blsSecretKey *sec, const void *h, mclSize size)
+{
+	G1 Hm;
+	Fp t;
+	t.setArrayMask((const char*)h, size);
+	BN::mapToG1(Hm, t);
+	mclBnG1_mulCT(&sig->v, cast(&Hm), &sec->v);
+}
+
 /*
 	e(P1, Q1) == e(P2, Q2)
 	<=> finalExp(ML(P1, Q1)) == finalExp(ML(P2, Q2))
@@ -147,6 +156,19 @@ int blsVerify(const blsSignature *sig, const blsPublicKey *pub, const void *m, m
 		e(sig, Q) = e(Hm, pub)
 	*/
 	return isEqualTwoPairings(*cast(&sig->v), getQcoeff().data(), Hm, *cast(&pub->v));
+}
+
+int blsVerifyHash(const blsSignature *sig, const blsPublicKey *pub, const void *h, mclSize size)
+{
+    G1 Hm;
+    Fp t;
+    t.setArrayMask((const char*)h, size);
+    BN::mapToG1(Hm, t);
+    /*
+        e(sHm, Q) = e(Hm, sQ)
+        e(sig, Q) = e(Hm, pub)
+    */
+    return isEqualTwoPairings(*cast(&sig->v), getQcoeff().data(), Hm, *cast(&pub->v));
 }
 
 mclSize blsIdSerialize(void *buf, mclSize maxBufSize, const blsId *id)


### PR DESCRIPTION
This PR adds support for signHash/verifyHash and verifyAggregatedHashes. The code for aggregated verification is based on https://github.com/herumi/mcl/blob/265b4649f4b456e3fe5fcdce4ca436167adc78e4/include/mcl/aggregate_sig.hpp#L109.

The reason to allow signing of raw hashes is that we don't want to rely on the internals of the BLS library when it comes to hashing. We use internal wrappers around the BLS library which forces us to provide a public key every time we sign something. This public key is than hashed together with the actual message to prevent rogue public key attacks.

verifyAggregatedHashes is useful for us as we do batched verification as much as possible to reduce the number of required pairings.

I also added tests for verifyAggregatedHashes, but noticed that they fail for some reason on BLS12_381. The last check in the test modifies the first input hash and asserts that verification fails. For some reason, this works well on all the other curves but fails on the BLS12_381. Expected behavior would be that verification fails.

I'm not sure if this is related to the verifyAggregatedHashes function or if there is some general error in the BLS12_381 implementation and might need some advise here.