### PR TITLE
Modify Travis CI build script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
-sudo: required
+sudo: false
 dist: trusty
 language: cpp
 compiler:
   - gcc
   - clang
-before_install:
-  - sudo apt install -y libgmp-dev
+addons:
+  apt:
+    packages:
+      - libgmp-dev
+install:
+  - git clone --depth 1 https://github.com/herumi/mcl.git $TRAVIS_BUILD_DIR/../mcl
 script:
-  - git clone --depth 1 https://github.com/herumi/mcl.git
-  - git clone --depth 1 https://github.com/herumi/bls.git
-  - cd bls
-  - make
+  - make -j3
   - make test DISABLE_THREAD_TEST=1
   - make test_go
   - bin/bls_c384_test.exe


### PR DESCRIPTION
1. Disable `sudo` to speed up boot time. ref: https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system
2. Remove `before_install` and use `addons` to install `libgmp-dev`
3. Cloning only the `mcl` reposity for dependency.
4. Speed up build time by adding `-j3` to `make`