### PR TITLE
Make it possible to build BLS as an independent package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set(LIBS mcl gmp gmpxx crypto pthread)
 
-set(MCL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../mcl/" CACHE PATH "mcl source dir")
-include_directories(
-	${MCL_DIR}/src ./include/
-)
+include_directories(./include/)
 
 add_library(bls_c256 SHARED src/bls_c256.cpp)
 add_library(bls_c384 SHARED src/bls_c384.cpp)

--- a/src/bls_c_impl.hpp
+++ b/src/bls_c_impl.hpp
@@ -3,7 +3,7 @@
 
 #include <bls/bls.h>
 
-#if 1
+#if 0
 #include "bn_c_impl.hpp"
 #else
 #if MCLBN_FP_UNIT_SIZE == 4 && MCLBN_FR_UNIT_SIZE == 4


### PR DESCRIPTION
This minor fix allows us to perform the standard cmake installation steps as described [here](https://github.com/herumi/bls/issues/17#issuecomment-444651995), which is a pattern that is supposed to work for all open-source CMake packages. This makes it infinitely easier to package for distributions like Nix and Debian.
