### PR TITLE
shared libraries should be linked to their dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,16 +5,16 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-set(LIBS mcl gmp gmpxx crypto pthread)
+set(LIBS mcl gmp)
 
 include_directories(include/)
 
 add_library(bls_c256 SHARED src/bls_c256.cpp)
 add_library(bls_c384 SHARED src/bls_c384.cpp)
 add_library(bls_c384_256 SHARED src/bls_c384_256.cpp)
-target_link_libraries(bls_c256)
-target_link_libraries(bls_c384)
-target_link_libraries(bls_c384_256)
+target_link_libraries(bls_c256 ${LIBS})
+target_link_libraries(bls_c384 ${LIBS})
+target_link_libraries(bls_c384_256 ${LIBS})
 
 file(GLOB BLS_HEADERS include/bls/bls.h include/bls/bls.hpp)
 
@@ -24,8 +24,8 @@ install(TARGETS bls_c384_256 DESTINATION lib)
 install(FILES ${BLS_HEADERS} DESTINATION include/bls)
 
 add_executable(bls_c256_test test/bls_c256_test.cpp)
-target_link_libraries(bls_c256_test bls_c256 ${LIBS})
+target_link_libraries(bls_c256_test bls_c256)
 add_executable(bls_c384_test test/bls_c384_test.cpp)
-target_link_libraries(bls_c384_test bls_c384 ${LIBS})
+target_link_libraries(bls_c384_test bls_c384)
 add_executable(bls_c384_256_test test/bls_c384_256_test.cpp)
-target_link_libraries(bls_c384_256_test bls_c384_256 ${LIBS})
+target_link_libraries(bls_c384_256_test bls_c384_256)


### PR DESCRIPTION
Otherwise, the build fails when another project wants to link only to bls (but not directly to mcl/ssl/crypto/gmp/gmpxx because it doesn't directly use them).
