### PR TITLE
Fix seg fault

### DIFF
--- a/ffi/go/bls/bls.go
+++ b/ffi/go/bls/bls.go
@@ -14,12 +14,19 @@ package bls
 */
 import "C"
 import "fmt"
+import "log"
 import "unsafe"
 
-// Init --
+func init() {
+	if err := initializeBLS(BLS12_381); err != nil {
+		log.Fatalf("Could not initialize BLS12-381 curve: %v", err)
+	}
+}
+
+// initializeBLS --
 // call this function before calling all the other operations
 // this function is not thread safe
-func Init(curve int) error {
+func initializeBLS(curve int) error {
 	err := C.blsInit(C.int(curve), C.MCLBN_COMPILED_TIME_VAR)
 	if err != 0 {
 		return fmt.Errorf("ERR Init curve=%d", curve)

--- a/ffi/go/bls/bls.go
+++ b/ffi/go/bls/bls.go
@@ -14,19 +14,12 @@ package bls
 */
 import "C"
 import "fmt"
-import "log"
 import "unsafe"
 
-func init() {
-	if err := initializeBLS(BLS12_381); err != nil {
-		log.Fatalf("Could not initialize BLS12-381 curve: %v", err)
-	}
-}
-
-// initializeBLS --
+// Init --
 // call this function before calling all the other operations
 // this function is not thread safe
-func initializeBLS(curve int) error {
+func Init(curve int) error {
 	err := C.blsInit(C.int(curve), C.MCLBN_COMPILED_TIME_VAR)
 	if err != 0 {
 		return fmt.Errorf("ERR Init curve=%d", curve)

--- a/ffi/go/bls/bls.go
+++ b/ffi/go/bls/bls.go
@@ -229,6 +229,11 @@ func (pub *PublicKey) Add(rhs *PublicKey) {
 	G2Add(&pub.v, &pub.v, &rhs.v)
 }
 
+// Sub --
+func (pub *PublicKey) Sub(rhs *PublicKey) {
+	G2Sub(&pub.v, &pub.v, &rhs.v)
+}
+
 // Set --
 func (pub *PublicKey) Set(mpk []PublicKey, id *ID) error {
 	// #nosec

--- a/ffi/go/bls/bls.go
+++ b/ffi/go/bls/bls.go
@@ -328,6 +328,9 @@ func (sign *Sign) Verify(pub *PublicKey, m string) bool {
 
 // VerifyPop --
 func (sign *Sign) VerifyPop(pub *PublicKey) bool {
+	if pub.getPointer() == nil {
+		return false
+	}
 	return C.blsVerifyPop(sign.getPointer(), pub.getPointer()) == 1
 }
 
@@ -350,6 +353,9 @@ func HashAndMapToSignature(buf []byte) *Sign {
 
 // VerifyPairing --
 func VerifyPairing(X *Sign, Y *Sign, pub *PublicKey) bool {
+	if X.getPointer() == nil || Y.getPointer() == nil || pub.getPointer() == nil {
+		return false
+	}
 	return C.blsVerifyPairing(X.getPointer(), Y.getPointer(), pub.getPointer()) == 1
 }
 
@@ -368,6 +374,9 @@ func (sec *SecretKey) SignHash(hash []byte) (sign *Sign) {
 // VerifyHash --
 func (sign *Sign) VerifyHash(pub *PublicKey, hash []byte) bool {
 	// #nosec
+	if pub.getPointer() == nil {
+		return false
+	}
 	return C.blsVerifyHash(sign.getPointer(), pub.getPointer(), unsafe.Pointer(&hash[0]), C.size_t(len(hash))) == 1
 }
 
@@ -386,6 +395,9 @@ func (sign *Sign) VerifyAggregateHashes(pubVec []PublicKey, hash [][]byte) bool 
 	for i := 0; i < n; i++ {
 		hn := len(hash[i])
 		copy(h[i*hashByte:(i+1)*hashByte], hash[i][0:Min(hn, hashByte)])
+	}
+	if pubVec[0].getPointer() == nil {
+		return false
 	}
 	return C.blsVerifyAggregatedHashes(sign.getPointer(), pubVec[0].getPointer(), unsafe.Pointer(&h[0]), C.size_t(hashByte), C.size_t(n)) == 1
 }


### PR DESCRIPTION
We encountered segfault when the pubkeys are not set.

This will prevent program seg fault when empty public keys were passed to the functions.

