### PR TITLE
Update bls_c_impl.hpp

### DIFF
--- a/src/bls_c_impl.hpp
+++ b/src/bls_c_impl.hpp
@@ -87,7 +87,7 @@ inline const mcl::FixedArray<Fp6, maxQcoeffN>& getQcoeff() { return g_Qcoeff; }
 int blsInit(int curve, int compiledTimeVar)
 {
 	if (compiledTimeVar != MCLBN_COMPILED_TIME_VAR) {
-		return -(compiledTimeVar | (MCLBN_COMPILED_TIME_VAR * 1000));
+		return -(compiledTimeVar + (MCLBN_COMPILED_TIME_VAR * 1000));
 	}
 	const mcl::CurveParam& cp = mcl::getCurveParam(curve);
 	bool b;


### PR DESCRIPTION
It seems that the error code was meant to show expected value concatenated with provided value, hence the 1000 multiplier.
However the bitwise | operator hides the value - for example:
246000 in binary
0b111100000011110000
146 in binary
0b10010010

so bitwise OR
0b111100000011110010
which is 246002 instead of 246146