### PR TITLE
Add mcl as submodule and improve cmake based build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ lib/*.dylib
 obj/*.d
 obj/*.o
 sample/*.txt
+!sample/CMakeLists.txt
+build/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mcl"]
+	path = external/mcl
+	url = https://github.com/bitFlyer-Blockchain/mcl.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,28 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.8)
 project(bls CXX ASM C)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-set(LIBS mcl gmp)
-
 option(
-	BLS_ETH
-	"Ethereum 2.0 spec"
-	"OFF"
+    BLS_BUILD_TESTING
+    "Build bls tests"
+    OFF
+)
+option(
+    BLS_BUILD_SAMPLE
+    "Build bls sample code"
+    OFF
+)
+option(
+    BLS_ETH
+    "Ethereum 2.0 spec"
+    "OFF"
 )
 
 if(BLS_ETH)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DBLS_ETH")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DBLS_ETH")
 endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS}")
@@ -24,41 +32,70 @@ if(MSVC)
         set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} /MD /W4 /Oy /Ox /EHsc /GS- /Zi /DNDEBUG /DNOMINMAX")
         set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} /MDd /W4 /DNOMINMAX")
     else()
-		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} /MT /W4 /Oy /Ox /EHsc /GS- /Zi /DNDEBUG /DNOMINMAX")
-	    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} /MTd /W4 /DNOMINMAX")
+        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} /MT /W4 /Oy /Ox /EHsc /GS- /Zi /DNDEBUG /DNOMINMAX")
+        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} /MTd /W4 /DNOMINMAX")
     endif()
 else()
-	if("${CFLAGS_OPT_USER}" STREQUAL "")
-		set(CFLAGS_OPT_USER "-O3 -DNDEBUG -march=native")
-	endif()
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat=2 -Wcast-qual -Wcast-align -Wwrite-strings -Wfloat-equal -Wpointer-arith ${CFLAGS_OPT_USER}")
-	set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS}")
+    if("${CFLAGS_OPT_USER}" STREQUAL "")
+        set(CFLAGS_OPT_USER "-O3 -DNDEBUG -march=native")
+    endif()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat=2 -Wcast-qual -Wcast-align -Wwrite-strings -Wfloat-equal -Wpointer-arith ${CFLAGS_OPT_USER}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS}")
 endif()
 
-include_directories(include/)
+add_subdirectory(external/mcl)
 
-add_library(bls_c256 SHARED src/bls_c256.cpp)
-add_library(bls_c384 SHARED src/bls_c384.cpp)
-add_library(bls_c384_256 SHARED src/bls_c384_256.cpp)
-target_link_libraries(bls_c256 ${LIBS})
-target_link_libraries(bls_c384 ${LIBS})
-target_link_libraries(bls_c384_256 ${LIBS})
+add_library(bls256 SHARED src/bls_c256.cpp)
+add_library(bls::bls256 ALIAS bls256)
+target_compile_definitions(bls256 PUBLIC MCLBN_NO_AUTOLINK BLS_NO_AUTOLINK)
+target_include_directories(bls256 PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_DIR}/include>)
+target_link_libraries(bls256 PUBLIC mcl::mclbn256)
 
-file(GLOB BLS_HEADERS include/bls/bls.h include/bls/bls.hpp)
+add_library(bls384 SHARED src/bls_c384.cpp)
+add_library(bls::bls384 ALIAS bls384)
+target_compile_definitions(bls384 PUBLIC MCLBN_NO_AUTOLINK BLS_NO_AUTOLINK)
+target_include_directories(bls384 PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_DIR}/include>)
+target_link_libraries(bls384 PUBLIC mcl::mclbn384)
 
-install(TARGETS bls_c256 DESTINATION lib)
-install(TARGETS bls_c384 DESTINATION lib)
-install(TARGETS bls_c384_256 DESTINATION lib)
-install(FILES ${BLS_HEADERS} DESTINATION include/bls)
+add_library(bls384_256 SHARED src/bls_c384_256.cpp)
+add_library(bls::bls384_256 ALIAS bls384_256)
+target_compile_definitions(bls384_256 PUBLIC MCLBN_NO_AUTOLINK BLS_NO_AUTOLINK)
+target_include_directories(bls384_256 PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_DIR}/include>)
+target_link_libraries(bls384_256 PUBLIC mcl::mclbn384_256)
 
-set(TEST_LIBS gmpxx)
 
-add_executable(bls_c256_test test/bls_c256_test.cpp)
-target_link_libraries(bls_c256_test bls_c256 ${TEST_LIBS})
-add_executable(bls_c384_test test/bls_c384_test.cpp)
-target_link_libraries(bls_c384_test bls_c384 ${TEST_LIBS})
-add_executable(bls_c384_256_test test/bls_c384_256_test.cpp)
-target_link_libraries(bls_c384_256_test bls_c384_256 ${TEST_LIBS})
+install(TARGETS bls256 bls384 bls384_256
+    EXPORT blsTargets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION lib)
+install(DIRECTORY include/bls
+    DESTINATION include)
+install(EXPORT blsTargets
+    FILE blsTargets.cmake
+    NAMESPACE bls::
+    DESTINATION lib/cmake/bls)
 
-add_executable(minsample sample/minsample.c)
-target_link_libraries(minsample bls_c384_256)
+export(EXPORT blsTargets
+    FILE blsTargets.cmake
+    NAMESPACE bls::)
+set(CMAKE_EXPORT_PACKAGE_REGISTERY ON)
+export(PACKAGE bls)
+
+# Tests
+if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR BLS_BUILD_TESTING)
+    AND BUILD_TESTING)
+    enable_testing()
+    add_subdirectory(test)
+endif()
+
+# Sample code
+if(BLS_BUILD_SAMPLE)
+    add_subdirectory(sample)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required (VERSION 3.8)
-project(bls CXX ASM C)
+
+project(bls
+  VERSION 1.10
+  LANGUAGES CXX ASM C)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -52,6 +55,10 @@ target_include_directories(bls256 PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_DIR}/include>)
 target_link_libraries(bls256 PUBLIC mcl::mclbn256)
+set_target_properties(bls256 PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+  VERSION ${bls_VERSION}
+  SONAME ${bls_VERSION_MAJOR})
 
 add_library(bls384 SHARED src/bls_c384.cpp)
 add_library(bls::bls384 ALIAS bls384)
@@ -60,6 +67,10 @@ target_include_directories(bls384 PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_DIR}/include>)
 target_link_libraries(bls384 PUBLIC mcl::mclbn384)
+set_target_properties(bls384 PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+  VERSION ${bls_VERSION}
+  SONAME ${bls_VERSION_MAJOR})
 
 add_library(bls384_256 SHARED src/bls_c384_256.cpp)
 add_library(bls::bls384_256 ALIAS bls384_256)
@@ -68,6 +79,10 @@ target_include_directories(bls384_256 PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_DIR}/include>)
 target_link_libraries(bls384_256 PUBLIC mcl::mclbn384_256)
+set_target_properties(bls384_256 PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+  VERSION ${bls_VERSION}
+  SONAME ${bls_VERSION_MAJOR})
 
 
 install(TARGETS bls256 bls384 bls384_256

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+BUILD_DIR=${1:-build}
+
+
+windows_build()
+{
+  if [ -d "${SCRIPT_DIR}/../cybozulib_ext"  ]; then
+      DOWNLOAD_CYBOZULIB_EXT="OFF"
+      CYBOZULIB_EXT_OPTION="-DMCL_CYBOZULIB_EXT_DIR:PATH=${SCRIPT_DIR}/../cybozulib_ext"
+  else
+      DOWNLOAD_CYBOZULIB_EXT="ON"
+      CYBOZULIB_EXT_OPTION=""
+  fi
+
+  cmake -E remove_directory ${BUILD_DIR}
+  cmake -E make_directory ${BUILD_DIR}
+  cmake -H${SCRIPT_DIR} -B${BUILD_DIR} -A x64 \
+    -DBUILD_TESTING=ON \
+    -DBLS_BUILD_SAMPLE=ON \
+    -DMCL_BUILD_SAMPLE=ON \
+    -DMCL_BUILD_TESTING=ON \
+    -DCMAKE_INSTALL_PREFIX=${BUILD_DIR}/install \
+    -DMCL_DOWNLOAD_SOURCE=${DOWNLOAD_CYBOZULIB_EXT} ${CYBOZULIB_EXT_OPTION}
+  cmake --build ${BUILD_DIR} --clean-first --config Release --parallel
+}
+
+linux_build()
+{
+  cmake -E remove_directory ${BUILD_DIR}
+  cmake -E make_directory ${BUILD_DIR}
+  cmake -H${SCRIPT_DIR} -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTING=ON \
+    -DBLS_BUILD_SAMPLE=ON \
+    -DMCL_BUILD_SAMPLE=ON \
+    -DMCL_USE_LLVM=ON \
+    -DMCL_USE_OPENSSL=ON \
+    -DMCL_BUILD_TESTING=ON \
+    -DCMAKE_INSTALL_PREFIX=${BUILD_DIR}/install
+  cmake --build ${BUILD_DIR} --clean-first -- -j
+}
+
+osx_build()
+{
+  # needed by mcl
+  OPENSSL_ROOT_DIR="/usr/local/opt/openssl"
+
+  cmake -E remove_directory ${BUILD_DIR}
+  cmake -E make_directory ${BUILD_DIR}
+  cmake -H${SCRIPT_DIR} -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTING=ON \
+    -DBLS_BUILD_SAMPLE=ON \
+    -DMCL_BUILD_SAMPLE=ON \
+    -DMCL_USE_LLVM=ON \
+    -DMCL_USE_OPENSSL=ON \
+    -DMCL_BUILD_TESTING=ON \
+    -DOPENSSL_ROOT_DIR="${OPENSSL_ROOT_DIR}" \
+    -DCMAKE_INSTALL_PREFIX=${BUILD_DIR}/install
+  cmake --build ${BUILD_DIR} --clean-first -- -j
+}
+
+os=`uname -s`
+case "${os}" in
+  CYGWIN*|MINGW32*|MSYS*|MINGW*)
+    windows_build
+    ;;
+  Darwin*)
+    osx_build
+    ;;
+  *)
+    linux_build
+    ;;
+esac

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -1,0 +1,12 @@
+# BLS sample code
+add_executable(bls_sample bls_smpl.cpp)
+target_link_libraries(bls_sample PRIVATE bls::bls384_256)
+target_compile_definitions(bls_sample  PRIVATE BLS_DONT_EXPORT)
+
+add_executable(bls12_381_sample bls12_381_smpl.cpp)
+target_link_libraries(bls12_381_sample PRIVATE bls::bls384_256)
+target_compile_definitions(bls12_381_sample  PRIVATE BLS_DONT_EXPORT)
+
+add_executable(minsample minsample.c)
+target_link_libraries(minsample PRIVATE bls::bls384_256)
+target_compile_definitions(minsample  PRIVATE BLS_DONT_EXPORT)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,32 @@
+# BLS Tests
+find_package(Threads REQUIRED)
+
+add_executable(bls_c256_test bls_c256_test.cpp)
+target_link_libraries(bls_c256_test PRIVATE bls::bls256 Threads::Threads)
+target_compile_definitions(bls_c256_test PRIVATE BLS_DONT_EXPORT)
+add_test(NAME bls_c256_test COMMAND bls_c256_test)
+
+add_executable(bls_c384_test bls_c384_test.cpp)
+target_link_libraries(bls_c384_test PRIVATE bls::bls384 Threads::Threads)
+target_compile_definitions(bls_c384_test  PRIVATE BLS_DONT_EXPORT)
+add_test(NAME bls_c384_test COMMAND bls_c384_test)
+
+add_executable(bls_c384_256_test bls_c384_256_test.cpp)
+target_link_libraries(bls_c384_256_test PRIVATE bls::bls384_256 Threads::Threads)
+target_compile_definitions(bls_c384_256_test  PRIVATE BLS_DONT_EXPORT)
+add_test(NAME bls_c384_256_test COMMAND bls_c384_256_test)
+
+add_executable(bls256_test bls256_test.cpp)
+target_link_libraries(bls256_test PRIVATE bls::bls256 Threads::Threads)
+target_compile_definitions(bls256_test PRIVATE BLS_DONT_EXPORT)
+add_test(NAME bls256_test COMMAND bls256_test)
+
+add_executable(bls384_test bls384_test.cpp)
+target_link_libraries(bls384_test PRIVATE bls::bls384 Threads::Threads)
+target_compile_definitions(bls384_test  PRIVATE BLS_DONT_EXPORT)
+add_test(NAME bls384_test COMMAND bls384_test)
+
+add_executable(bls384_256_test bls384_256_test.cpp)
+target_link_libraries(bls384_256_test PRIVATE bls::bls384_256 Threads::Threads)
+target_compile_definitions(bls384_256_test  PRIVATE BLS_DONT_EXPORT)
+add_test(NAME bls384_256_test COMMAND bls384_256_test)


### PR DESCRIPTION
This PR improves cmake build and add a convenience build shell script for Linux, macOS, Windows (using Git Bash). It also uses mcl as git submodule to build it as a dependency.