### PR TITLE
Fix link issue on windows :'cannot open file blsxxx.lib'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ add_subdirectory(external/mcl)
 foreach(bit IN ITEMS 256 384 384_256)
 	add_library(bls${bit} SHARED src/bls_c${bit}.cpp)
 	add_library(bls::bls${bit} ALIAS bls${bit})
+	target_compile_definitions(bls${bit} PRIVATE BLS_NO_AUTOLINK)
 	target_include_directories(bls${bit} PUBLIC
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 		$<INSTALL_INTERFACE:${CMAKE_INSTALL_DIR}/include>)


### PR DESCRIPTION
On Windows creating blsxxx.dll fails:

```
LINK : fatal error LNK1104: cannot open file 'bls256.lib' [C:\source\repos\bls\build\bls256.vcxproj]
LINK : fatal error LNK1104: cannot open file 'bls384_256.lib' [C:\source\repos\bls\build\bls384_256.vcxproj]
LINK : fatal error LNK1104: cannot open file 'bls384.lib' [C:\source\repos\bls\build\bls384.vcxproj]
``` 

This PR seems to fix the problem.