### PR TITLE
Add missing interface, tweaks for compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ option(
 option(
 	BLS_ETH
 	"Ethereum 2.0 spec"
-	"OFF"
+	"ON"
 )
 
 if(BLS_ETH)
@@ -40,7 +40,7 @@ if(MSVC)
 	endif()
 else()
 	if("${CFLAGS_OPT_USER}" STREQUAL "")
-		set(CFLAGS_OPT_USER "-O3 -DNDEBUG -march=native")
+		set(CFLAGS_OPT_USER "-O3 -DNDEBUG")
 	endif()
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat=2 -Wcast-qual -Wcast-align -Wwrite-strings -Wfloat-equal -Wpointer-arith ${CFLAGS_OPT_USER}")
 	set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS}")

--- a/ffi/cs/App.config
+++ b/ffi/cs/App.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
-    </startup>
-</configuration>

--- a/ffi/cs/bls.cs
+++ b/ffi/cs/bls.cs
@@ -145,6 +145,10 @@ namespace mcl
         [DllImport(dllName)] public static extern int blsFastAggregateVerify(in Signature sig, in PublicKey pubVec, ulong n, [In]byte[] msg, ulong msgSize);
         [DllImport(dllName)] public static extern int blsAggregateVerifyNoCheck(in Signature sig, in PublicKey pubVec, in Msg msgVec, ulong msgSize, ulong n);
 
+        [DllImport(dllName)]
+        public static extern int blsMultiVerify(in Signature sigVec, in PublicKey pubVec, in Msg msgVec,
+            ulong msgSize, in SecretKey randVec, ulong randSize, ulong n, int threadN);
+        
         // don't call this if isETH = true, it calls in BLS()
         public static void Init(int curveType = BLS12_381) {
             if (isETH && isInit) return;
@@ -558,6 +562,25 @@ namespace mcl
                 return false;
             }
             return AggregateVerifyNoCheck(in sig, in pubVec, in msgVec);
+        }
+        public static bool MultiVerify(in Signature[] sigVec, in PublicKey[] pubVec, in Msg[] msgVec, in SecretKey[] randVec)
+        {
+            if (pubVec.Length != msgVec.Length) {
+                throw new ArgumentException("different length of pubVec and msgVec");
+            }
+            if (pubVec.Length != sigVec.Length)
+            {
+                throw new ArgumentException("different length of pubVec and sigVec");
+            }
+            if (pubVec.Length != randVec.Length)
+            {
+                throw new ArgumentException("different length of pubVec and randVec");
+            }
+            ulong n = (ulong)pubVec.Length;
+            if (n == 0) {
+                throw new ArgumentException("pubVec is empty");
+            }
+            return blsMultiVerify(in sigVec[0], in pubVec[0], in msgVec[0], MSG_SIZE, in randVec[0], n, n, 4) == 1;
         }
     }
 }

--- a/ffi/cs/bls.csproj
+++ b/ffi/cs/bls.csproj
@@ -1,17 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{E9D06B1B-EA22-4EF4-BA4B-422F7625966D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>bls</RootNamespace>
-    <AssemblyName>bls</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <OutputType>Library</OutputType>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -27,53 +17,13 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <DebugSymbols>true</DebugSymbols>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputPath>..\..\bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>7.2</LangVersion>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>..\..\bin\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <NoWin32Manifest>true</NoWin32Manifest>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="bls.cs" />
-    <Compile Include="bls_test.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.5.2">
       <Visible>False</Visible>
@@ -86,12 +36,11 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="bls_eth.cs" />
+  </ItemGroup>
 </Project>

--- a/ffi/cs/bls.sln
+++ b/ffi/cs/bls.sln
@@ -2,8 +2,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.2.32630.192
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bls", "bls.csproj", "{E9D06B1B-EA22-4EF4-BA4B-422F7625966D}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bls_eth", "bls_eth.csproj", "{D32C3C79-9139-4488-AAD0-B6D28868BBA1}"
 EndProject
 Global
@@ -12,10 +10,6 @@ Global
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E9D06B1B-EA22-4EF4-BA4B-422F7625966D}.Debug|x64.ActiveCfg = Debug|x64
-		{E9D06B1B-EA22-4EF4-BA4B-422F7625966D}.Debug|x64.Build.0 = Debug|x64
-		{E9D06B1B-EA22-4EF4-BA4B-422F7625966D}.Release|x64.ActiveCfg = Release|x64
-		{E9D06B1B-EA22-4EF4-BA4B-422F7625966D}.Release|x64.Build.0 = Release|x64
 		{D32C3C79-9139-4488-AAD0-B6D28868BBA1}.Debug|x64.ActiveCfg = Debug|x64
 		{D32C3C79-9139-4488-AAD0-B6D28868BBA1}.Debug|x64.Build.0 = Debug|x64
 		{D32C3C79-9139-4488-AAD0-B6D28868BBA1}.Release|x64.ActiveCfg = Release|x64

--- a/ffi/cs/bls.sln
+++ b/ffi/cs/bls.sln
@@ -7,13 +7,19 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
+		Debug|Any CPU = Debug|Any CPU
 		Release|x64 = Release|x64
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D32C3C79-9139-4488-AAD0-B6D28868BBA1}.Debug|x64.ActiveCfg = Debug|x64
 		{D32C3C79-9139-4488-AAD0-B6D28868BBA1}.Debug|x64.Build.0 = Debug|x64
 		{D32C3C79-9139-4488-AAD0-B6D28868BBA1}.Release|x64.ActiveCfg = Release|x64
 		{D32C3C79-9139-4488-AAD0-B6D28868BBA1}.Release|x64.Build.0 = Release|x64
+		{D32C3C79-9139-4488-AAD0-B6D28868BBA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D32C3C79-9139-4488-AAD0-B6D28868BBA1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D32C3C79-9139-4488-AAD0-B6D28868BBA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D32C3C79-9139-4488-AAD0-B6D28868BBA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ffi/cs/bls_eth.cs
+++ b/ffi/cs/bls_eth.cs
@@ -145,6 +145,10 @@ namespace mcl
         [DllImport(dllName)] public static extern int blsFastAggregateVerify(in Signature sig, in PublicKey pubVec, ulong n, [In]byte[] msg, ulong msgSize);
         [DllImport(dllName)] public static extern int blsAggregateVerifyNoCheck(in Signature sig, in PublicKey pubVec, in Msg msgVec, ulong msgSize, ulong n);
 
+        [DllImport(dllName)]
+        public static extern int blsMultiVerify(in Signature sigVec, in PublicKey pubVec, in Msg msgVec,
+            ulong msgSize, in SecretKey randVec, ulong randSize, ulong n, int threadN);
+        
         // don't call this if isETH = true, it calls in BLS()
         public static void Init(int curveType = BLS12_381) {
             if (isETH && isInit) return;
@@ -558,6 +562,26 @@ namespace mcl
                 return false;
             }
             return AggregateVerifyNoCheck(in sig, in pubVec, in msgVec);
+        }
+        
+        public static bool MultiVerify(in Signature[] sigVec, in PublicKey[] pubVec, in Msg[] msgVec, in SecretKey[] randVec)
+        {
+            if (pubVec.Length != msgVec.Length) {
+                throw new ArgumentException("different length of pubVec and msgVec");
+            }
+            if (pubVec.Length != sigVec.Length)
+            {
+                throw new ArgumentException("different length of pubVec and sigVec");
+            }
+            if (pubVec.Length != randVec.Length)
+            {
+                throw new ArgumentException("different length of pubVec and randVec");
+            }
+            ulong n = (ulong)pubVec.Length;
+            if (n == 0) {
+                throw new ArgumentException("pubVec is empty");
+            }
+            return blsMultiVerify(in sigVec[0], in pubVec[0], in msgVec[0], MSG_SIZE, in randVec[0], n, n, 4) == 1;
         }
     }
 }

--- a/ffi/cs/bls_eth.cs
+++ b/ffi/cs/bls_eth.cs
@@ -544,7 +544,7 @@ namespace mcl
         public static bool AggregateVerifyNoCheck(in Signature sig, in PublicKey[] pubVec, in Msg[] msgVec)
         {
             if (pubVec.Length != msgVec.Length) {
-                    throw new ArgumentException("different lengt of pubVec and msgVec");
+                    throw new ArgumentException("different length of pubVec and msgVec");
             }
             ulong n = (ulong)pubVec.Length;
             if (n == 0) {

--- a/ffi/cs/bls_eth.csproj
+++ b/ffi/cs/bls_eth.csproj
@@ -1,17 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+п»ї<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D32C3C79-9139-4488-AAD0-B6D28868BBA1}</ProjectGuid>
-    <OutputType>Exe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <OutputType>Library</OutputType>
     <RootNamespace>bls</RootNamespace>
     <AssemblyName>bls</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -27,57 +19,17 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <DebugSymbols>true</DebugSymbols>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputPath>..\..\bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>7.2</LangVersion>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>..\..\bin\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <NoWin32Manifest>true</NoWin32Manifest>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="bls_eth.cs" />
-    <Compile Include="bls_test.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.5.2">
       <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.5.2 %28x86 ебґеЈиебЋі x64%29</ProductName>
+      <ProductName>Microsoft .NET Framework 4.5.2 %28x86 пїЅпїЅпїЅпїЅпїЅбЋі x64%29</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
     <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
@@ -86,12 +38,11 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="bls.cs" />
+  </ItemGroup>
 </Project>

--- a/ffi/cs/bls_test.cs
+++ b/ffi/cs/bls_test.cs
@@ -389,6 +389,74 @@ namespace mcl
                 assert("verify", AreAllMsgDifferent(msgVec) == t.expected);
             }
         }
+        static void TestMultiVerify()
+        {
+            Console.WriteLine("TestMultiVerify");
+            var tbl = new[] {
+                new {
+                    pubVec = new[] {
+                        "a491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+                        "b301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+                        "b53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+                    },
+                    msgVec = new[] {
+                        "0000000000000000000000000000000000000000000000000000000000000000",
+                        "5656565656565656565656565656565656565656565656565656565656565656",
+                        "abababababababababababababababababababababababababababababababab",
+                    },
+                    sigVec = new[]
+                    {
+                        "b6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380b55285a55",
+                        "af1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363272ba4fe",
+                        "ae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9",
+                    },
+                    expected = true,
+                },
+                new {
+                    pubVec = new[] {
+                        "a491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+                        "b301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+                    },
+                    msgVec = new[] {
+                        "0000000000000000000000000000000000000000000000000000000000000000",
+                        "5656565656565656565656565656565656565656565656565656565656565656",
+                    },
+                    sigVec = new[]
+                    {
+                        "a70f1f1b4bd97d182ebb55d08be3f90b1dc232bb50b44e259381a642ef0bad3629ad3542f3e8ff6a84e451fc0b595e090fc4f0e860cfc5584715ef1b6cd717b9994378f7a51b815bbf5a0d95bc3402583ad2e95a229731e539906249a5e4355c",
+                        "b758eb7e15c101f53be2214d2a6b65e8fe7053146dbe3c73c9fe9b5efecdf63ca06a4d5d938dbf18fe6600529c0011a7013f45ae012b02904d5c7c33316e935a0e084abead4f43f84383c52cd3b3f14024437e251a2a7c0d5147954022873a58",
+                    },
+                    expected = false,
+                },
+            };
+            foreach (var v in tbl) {
+                int n = v.pubVec.Length;
+                PublicKey[] pubVec = new PublicKey[n];
+                SecretKey[] randVec = new SecretKey[n];
+                bool result = false;
+                try {
+                    for (int i = 0; i < n; i++) {
+                        pubVec[i].Deserialize(FromHexStr(v.pubVec[i]));
+                    }
+                    Msg[] msgVec = new Msg[n];
+                    for (int i = 0; i < n; i++) {
+                        msgVec[i].Set(FromHexStr(v.msgVec[i]));
+                    }
+                    Signature[] sigVec = new Signature[n];
+                    for (int i = 0; i < n; i++) {
+                        sigVec[i].Deserialize(FromHexStr(v.sigVec[i]));
+                    }
+                    for (int i = 0; i < n; i++)
+                    {
+                        _ = blsSecretKeySetByCSPRNG(ref randVec[i]);
+                    }
+                    result = MultiVerify(sigVec, pubVec, msgVec, randVec);
+                } catch (Exception) {
+                    // pass through
+                }
+                assert("MultiVerify", result == v.expected);
+            }
+        }
         static void Main(string[] args) {
             try {
                 int[] curveTypeTbl = { BN254, BLS12_381 };
@@ -411,6 +479,7 @@ namespace mcl
                     if (isETH) {
                         TestFastAggregateVerify();
                         TestAggregateVerify();
+                        TestMultiVerify();
                     }
                     if (err == 0) {
                         Console.WriteLine("all tests succeed");


### PR DESCRIPTION
### Changelog
- Convert to project from .Net Framework to .Net Core, specifically netstandard2.0, See reason why it is [here](https://github.com/planetarium/libplanet/issues/1266).)
- Add missing interface to `MultiVerify()`
- remove compiler parameter `-march=native` due to compiling fail in Apple Silicon