### PR TITLE
Fix Typo in `bls.hpp`

### DIFF
--- a/include/bls/bls.hpp
+++ b/include/bls/bls.hpp
@@ -166,7 +166,7 @@ public:
 		local::convertArray(x, p, n);
 		setLittleEndian(x, n * sizeof(uint64_t));
 	}
-	// bufSize is truncted/zero extended to keySize
+	// bufSize is truncated/zero extended to keySize
 	void setLittleEndian(const uint8_t *buf, size_t bufSize)
 	{
 		mclBnFr_setLittleEndian(&self_.v, buf, bufSize);


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `bls.hpp`**

## Description  
This pull request corrects a typo in the `bls.hpp` file. The word "truncted" has been corrected to "truncated" to ensure proper spelling and clarity.

### Changes Made:
- **File Modified:** `bls.hpp`
- **Summary of Changes:**  
  - Corrected the typo from "truncted" to "truncated" in the comment on line 166.

## Checklist  
- [ ] Fixed the typo in the file.
- [x] Verified that the code comment is now correctly spelled.

## Additional Notes  
This change improves the readability and professionalism of the code comments.

---

**Allow edits by maintainers:** [x]
