### PR TITLE
Typo fix in bls.h

### DIFF
--- a/include/bls/bls.h
+++ b/include/bls/bls.h
@@ -389,7 +389,7 @@ BLS_DLL_API void blsDHKeyExchange(blsPublicKey *out, const blsSecretKey *sec, co
 	https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html
 	H(pubVec)_i := SHA-256(pubVec[0], ..., pubVec[n-1], 4-byte little endian(i))
 	@note
-	1. this hash function will be modifed in the future
+	1. this hash function will be modified in the future
 	2. sigVec and pubVec are not const because they may be normalized (the value are not changed)
 */
 // aggSig = sum sigVec[i] t_i where (t_1, ..., t_n) = H({pubVec})


### PR DESCRIPTION
# Pull Request Title: Typo fix in bls.h

## Description:
This pull request corrects a typo in the `bls.h` file, where "modifed" was changed to "modified."

## Changes:
- Corrected the spelling of "modifed" to "modified."

## File(s) Modified:
- `include/bls/bls.h`

## Reasoning:
Fixing this typo ensures proper spelling, which improves the clarity and professionalism of the code comments.

## Checklist:
- [x] The code follows the project's coding guidelines.
- [x] All relevant tests are passing.
- [x] I have updated the documentation (if necessary).
- [x] I have tested the changes locally.

## Related Issues:
N/A

## Additional Notes:
N/A
